### PR TITLE
Add a check for xml files to avoid html generation

### DIFF
--- a/lib/jekyll-images-cdn.rb
+++ b/lib/jekyll-images-cdn.rb
@@ -4,6 +4,7 @@ require 'nokogiri'
 module Jekyll
   class ImagesCdn
     def self.modify_images(page)
+      return unless page.relative_path.end_with?(".html")
       return unless page.output.start_with?("<")
 
       config = page.site.config


### PR DESCRIPTION
This PR adds an extra check before modifying cdn images to ensure that xml files are not converted to HTML docs. This is needed to retain xml file formats and fixes issue with broken RSS feed