### PR TITLE
Allow to use jeyll-images-cdn for pages written in markdown

### DIFF
--- a/lib/jekyll-images-cdn.rb
+++ b/lib/jekyll-images-cdn.rb
@@ -4,7 +4,7 @@ require 'nokogiri'
 module Jekyll
   class ImagesCdn
     def self.modify_images(page)
-      return unless page.relative_path.end_with?(".html")
+      return unless page.relative_path.end_with?(".html") or page.relative_path.end_with?(".md")
       return unless page.output.start_with?("<")
 
       config = page.site.config


### PR DESCRIPTION
Without this fix, the plugin ignores the files generated from .md files (the extension is not yet transformed to html apparently)